### PR TITLE
Improved 'save()' method

### DIFF
--- a/TextureToolkit/src/com/Texture.java
+++ b/TextureToolkit/src/com/Texture.java
@@ -28,7 +28,7 @@ public class Texture {
 	public void save(String path)
 	{
 		// Check the string contains a ".", if not we cannot save the file
-		if (!banana.contains(".")) {
+		if (!path.contains(".")) {
             		System.out.println("The path given does not contain an extension");
             		return;
 		}

--- a/TextureToolkit/src/com/Texture.java
+++ b/TextureToolkit/src/com/Texture.java
@@ -27,8 +27,15 @@ public class Texture {
 
 	public void save(String path)
 	{
+		// Check the string contains a ".", if not we cannot save the file
+		if (!banana.contains(".")) {
+            		System.out.println("The path given does not contain an extension");
+            		return;
+		}
 		
-		String extension = path.substring(path.length() - 3 );
+		// Retrieve the last substring of 'path' after the final "."
+		String[] parts = path.split("\\.");
+		String extension = parts[parts.length - 1];
 		
 		try {
 		    // retrieve image		   


### PR DESCRIPTION
If the path does not contain a "." then it is not a properly formed path, so the method now outputs this error and returns out of the method.
Other checks could be done to properly ensure that an erroneous path has been given, such as certain characters that cannot be used in a path.
Also, Instead of presuming the extension is only length 3, this change will allow extensions of any length to be passed to the method.
